### PR TITLE
DC-3489 : update SBT resolvers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val appName: String = "secure-message-stub"
 val silencerVersion = "1.6.0"
 
 lazy val root = (project in file("."))
-  .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin, SbtArtifactory)
+  .enablePlugins(PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(DefaultBuildSettings.scalaSettings: _*)
   .settings(DefaultBuildSettings.defaultSettings(): _*)
@@ -51,10 +51,6 @@ lazy val root = (project in file("."))
     retrieveManaged := true,
     evictionWarningOptions in update :=
       EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
-    resolvers ++= Seq(
-      Resolver.bintrayRepo("hmrc", "releases"),
-      Resolver.jcenterRepo
-    ),
     // concatenate js
     Concat.groups := Seq(
       "javascripts/securemessagestub-app.js" ->

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.3.6
+sbt.version=1.3.13
 hmrc-frontend-scaffold.version=0.18.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,9 @@
-resolvers += Resolver.url(
-  "HMRC Sbt Plugin Releases",
-  url("https://dl.bintray.com/hmrc/sbt-plugin-releases")
-)(Resolver.ivyStylePatterns)
-resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
-resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.12.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
+resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
+resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
+
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.0.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.12.0")
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.7")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")


### PR DESCRIPTION
This commit provides:

- New SBT resolvers as per https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=256476338
- Upgrade to sbt-auto-build version 3.0 as per https://confluence.tools.tax.service.gov.uk/display/TEC/2021/05/05/New+version+of+sbt-auto-build
- Upgrade all 3rd party dependencies as required by the build